### PR TITLE
fix: Workaround to not require hnsw batch params when updating an index

### DIFF
--- a/cmd/indexUpdate.go
+++ b/cmd/indexUpdate.go
@@ -94,12 +94,17 @@ asvec index update -i myindex -n test --%s 10000 --%s 10000ms --%s 10s --%s 16 -
 			}
 			defer adminClient.Close()
 
-			hnswParams := &protos.HnswIndexUpdate{
-				MaxMemQueueSize: indexUpdateFlags.hnswMaxMemQueueSize.Val,
-				BatchingParams: &protos.HnswBatchingParams{
+			var batchingParams *protos.HnswBatchingParams
+			if indexUpdateFlags.hnswBatch.MaxRecords.Val != nil || indexUpdateFlags.hnswBatch.Interval.Uint32() != nil {
+				batchingParams = &protos.HnswBatchingParams{
 					MaxRecords: indexUpdateFlags.hnswBatch.MaxRecords.Val,
 					Interval:   indexUpdateFlags.hnswBatch.Interval.Uint32(),
-				},
+				}
+			}
+
+			hnswParams := &protos.HnswIndexUpdate{
+				MaxMemQueueSize: indexUpdateFlags.hnswMaxMemQueueSize.Val,
+				BatchingParams:  batchingParams,
 				CachingParams: &protos.HnswCachingParams{
 					MaxEntries: indexUpdateFlags.hnswCache.MaxEntries.Val,
 					Expiry:     indexUpdateFlags.hnswCache.Expiry.Uint64(),
@@ -114,14 +119,6 @@ asvec index update -i myindex -n test --%s 10000 --%s 10000ms --%s 10s --%s 16 -
 				MergeParams: &protos.HnswIndexMergeParams{
 					Parallelism: indexUpdateFlags.hnswMerge.Parallelism.Val,
 				},
-			}
-
-			if !indexUpdateFlags.yes && !confirm(fmt.Sprintf(
-				"Are you sure you want to update the index %s.%s?",
-				indexUpdateFlags.namespace,
-				indexUpdateFlags.indexName,
-			)) {
-				return nil
 			}
 
 			ctx, cancel := context.WithTimeout(context.Background(), indexUpdateFlags.clientFlags.Timeout)

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -364,11 +364,9 @@ func (suite *CmdTestSuite) TestSuccessfulUpdateIndexCmd() {
 			"test with hnsw params and seeds",
 			"successful-update",
 			ns,
-			fmt.Sprintf("index update -y --seeds %s -n test -i successful-update --index-labels new-label=foo --hnsw-max-mem-queue-size 10 --hnsw-batch-max-records 100  --hnsw-batch-interval 10s", suite.avsHostPort.String()),
+			fmt.Sprintf("index update -y --seeds %s -n test -i successful-update --index-labels new-label=foo --hnsw-max-mem-queue-size 10", suite.avsHostPort.String()),
 			builder.
 				WithLabels(map[string]string{"new-label": "foo"}).
-				WithHnswBatchingInterval(10000).
-				WithHnswBatchingMaxRecord(100).
 				WithHnswMaxMemQueueSize(10).
 				Build(),
 		},
@@ -386,7 +384,7 @@ func (suite *CmdTestSuite) TestSuccessfulUpdateIndexCmd() {
 			"test with hnsw cache params",
 			"successful-update",
 			"test",
-			fmt.Sprintf("index update -y --host %s -n test -i successful-update --hnsw-cache-max-entries 1000 --hnsw-cache-expiry 10s --hnsw-batch-interval 50s --hnsw-batch-max-records 100", suite.avsHostPort.String()),
+			fmt.Sprintf("index update -y --host %s -n test -i successful-update --hnsw-cache-max-entries 1000 --hnsw-cache-expiry 10s", suite.avsHostPort.String()),
 			builder.
 				WithHnswCacheExpiry(10000).
 				WithHnswCacheMaxEntries(1000).
@@ -396,7 +394,7 @@ func (suite *CmdTestSuite) TestSuccessfulUpdateIndexCmd() {
 			"test with hnsw healer params",
 			"successful-update",
 			"test",
-			fmt.Sprintf("index update -y s --host %s -n test -i successful-update --hnsw-healer-max-scan-rate-per-node 1000 --hnsw-healer-max-scan-page-size 1000 --hnsw-healer-reindex-percent 10.10 --hnsw-healer-schedule-delay 10s --hnsw-healer-parallelism 10 --hnsw-batch-interval 50s --hnsw-batch-max-records 100", suite.avsHostPort.String()),
+			fmt.Sprintf("index update -y s --host %s -n test -i successful-update --hnsw-healer-max-scan-rate-per-node 1000 --hnsw-healer-max-scan-page-size 1000 --hnsw-healer-reindex-percent 10.10 --hnsw-healer-schedule-delay 10s --hnsw-healer-parallelism 10", suite.avsHostPort.String()),
 			builder.
 				WithHnswHealerMaxScanRatePerNode(1000).
 				WithHnswHealerMaxScanPageSize(1000).
@@ -409,7 +407,7 @@ func (suite *CmdTestSuite) TestSuccessfulUpdateIndexCmd() {
 			"test with hnsw merge params",
 			"successful-update",
 			"test",
-			fmt.Sprintf("index update -y s --host %s -n test -i successful-update --hnsw-merge-parallelism 10  --hnsw-batch-interval 50s --hnsw-batch-max-records 100", suite.avsHostPort.String()),
+			fmt.Sprintf("index update -y s --host %s -n test -i successful-update --hnsw-merge-parallelism 10", suite.avsHostPort.String()),
 			builder.
 				WithHnswMergeParallelism(10).
 				Build(),


### PR DESCRIPTION
There is still a limitation: If you provide one of the batch indexes, you must provide both.

Also, I remove the update prompt per Adam's request