### PR TITLE
build: pin setup-gpg, setup dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directories:
+      - /
+    schedule:
+      interval: daily

--- a/.github/workflows/create-prerelease.yml
+++ b/.github/workflows/create-prerelease.yml
@@ -244,7 +244,7 @@ jobs:
         with:
           name: asvec-artifacts
       - name: setup GPG
-        uses: aerospike/shared-workflows/devops/setup-gpg@main
+        uses: aerospike/shared-workflows/devops/setup-gpg@v0.1.0
         with:
           gpg-private-key: ${{ secrets.GPG_SECRET_KEY }}
           gpg-public-key: ${{ secrets.GPG_PUBLIC_KEY }}

--- a/.github/workflows/create-prerelease.yml
+++ b/.github/workflows/create-prerelease.yml
@@ -463,7 +463,7 @@ jobs:
             jfrog rt build-collect-env "${{ env.JFROG_CLI_BUILD_NAME }}-rpm" "${{ needs.build.outputs.version }}"
             jfrog rt build-add-git "${{ env.JFROG_CLI_BUILD_NAME }}-rpm" "${{ needs.build.outputs.version }}"
             jfrog rt build-publish "${{ env.JFROG_CLI_BUILD_NAME }}-rpm" "${{ needs.build.outputs.version }}" --project="${{env.JFROG_CLI_BUILD_PROJECT}}"
-# Our repositories currently don't support generic which would be needed for pkg and zip
+# TODO - add builds for macos and windows (likely need generic repo support in jfrog)
 
   publish-release-bundle: 
     needs: 

--- a/.github/workflows/create-prerelease.yml
+++ b/.github/workflows/create-prerelease.yml
@@ -244,7 +244,7 @@ jobs:
         with:
           name: asvec-artifacts
       - name: setup GPG
-        uses: aerospike/shared-workflows/devops/setup-gpg@v0.1.0
+        uses: aerospike/shared-workflows/devops/setup-gpg@ed780e9928d56ef074532dbc6877166d5460587a # v0.1.0
         with:
           gpg-private-key: ${{ secrets.GPG_SECRET_KEY }}
           gpg-public-key: ${{ secrets.GPG_PUBLIC_KEY }}

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -6,7 +6,7 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
         use-quiet-mode: yes


### PR DESCRIPTION
the setup-gpg action is going to move in the shared-workflows folder. 
Pinning to `main` isn't safe when that happens, so you should pin to the current semver version.

Also sets up dependabot to check and PR updates to actions weekly.