### PR TITLE
build(ci): add generate-homebrew-formula to build workflow vec-579

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -494,6 +494,29 @@ jobs:
             else
                 echo "No release found for tag ${TAG}, skipping upload to github"
             fi
+  
+  generate-homebrew-formula:
+    # the action that generates the homebrew formula in https://github.com/aerospike/homebrew-tools
+    # pulls artifacts from the release so we needs to wait for them to be uploaded
+    # Only run this job if triggered by a tag push (trigger under same conditions as add-binaries-to-release)
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    needs: [add-binaries-to-release, parse-version, sign, build, tests]
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Download Artifacts'
+        uses: actions/download-artifact@v4
+        with:
+          name: asvec-artifacts
+      - name: 'Generate Homebrew Formula'
+        run: |
+          version=${{ needs.parse-version.outputs.version }}
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.PAT }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/aerospike/homebrew-tools/dispatches \
+            -d "{\"event_type\": \"asvec\", \"client_payload\": {\"isLatest\": true, \"version\": \"$version\"}}"
 
   tests:
     needs: [parse-version]


### PR DESCRIPTION
This triggers the creation of homebrew formula in github.com/aerospike/homebrew-tools vec-579.

This is based off Robert's work at https://github.com/aerospike/aerolab/blob/e28674f03509a279655f56de07cb2e035ee67be6/.github/workflows/create-prerelease.yml#L313